### PR TITLE
Improve HTML semantics

### DIFF
--- a/assets/css/index/pc.css
+++ b/assets/css/index/pc.css
@@ -116,7 +116,7 @@
 		flex-direction: column;
 	}
 
-	.wrap-notice > h1 {
+	.wrap-notice > h2 {
 		margin-bottom: 1rem;
 		font-size: 3rem;
 		font-weight: 900;
@@ -140,7 +140,7 @@
 		margin-bottom: 10%;
 	}
 
-	.wrap-concept > h1 {
+	.wrap-concept > h2 {
 		margin-bottom: 1rem;
 		font-size: 3rem;
 		font-weight: 900;

--- a/assets/css/index/phone.css
+++ b/assets/css/index/phone.css
@@ -116,7 +116,7 @@
 		flex-direction: column;
 	}
 
-	.wrap-notice > h1 {
+	.wrap-notice h2 {
 		margin-top: 1rem;
 		margin-bottom: 1rem;
 		font-size: 1.8rem;
@@ -139,7 +139,7 @@
 		margin-bottom: 3rem;
 	}
 
-	.wrap-concept > h1 {
+	.wrap-concept > h2 {
 		margin-top: 3rem;
 		margin-bottom: 1rem;
 		font-size: 1.8rem;

--- a/components/navbar.vue
+++ b/components/navbar.vue
@@ -1,6 +1,6 @@
 <template>
-	<div class="navbar">
-	</div>
+	<nav class="navbar">
+	</nav>
 </template>
 
 <style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="container">
+  <main class="container">
 
 		<section class="wrap-image">
 			<img src="@/assets/logo/vi_published_t_13.svg" alt="ロゴ画像" class="logo-image-phone">
@@ -22,7 +22,7 @@
 		<!--
 		<section class="wrap-count">
 			<div class="count">
-				<h1 class="count-made">第74回灘校文化祭開催まで</h1>
+				<h2 class="count-made">第74回灘校文化祭開催まで</h2>
 				<div class="count-suji">
 					あと &nbsp;
 					<img :src="count10" alt="10の位" class="count-image">
@@ -36,7 +36,7 @@
 		</section>
 		-->
 		<section class="wrap-notice">
-			<h1 class="notice-h1">お知らせ</h1>
+			<h2 class="notice-h2">お知らせ</h2>
 			<p>
 				この度、5月2日～5月3日に開催を予定して<span class="text">おりました</span><br>
 				第74回灘校文化祭 “vivid” の開催中止を決定<span class="text">いたしました。</span><br>
@@ -45,7 +45,7 @@
 		</section>
 
 		<section class="wrap-concept">
-			<h1 class="concept-h1">Concept</h1>
+			<h2 class="concept-h2">Concept</h2>
 			<p>
 			“vivid” という言葉には、「生き生きとした」という意味が<span class="text">あります</span><br>
 			活動する生徒やご来場になる皆さんなど、全ての人にとって活力のあふれた文化祭になることを<span class="text">願ったテーマです</span><br>
@@ -138,7 +138,7 @@
 			</div>
 		</section>
 		-->
-  </div>
+  </main>
 </template>
 
 <script>


### PR DESCRIPTION
- トップページの`h1`を`2020灘校文化祭`を除き`h2`に
- メインの領域(`index.vue`のルート要素)を`div`から`main`に
- 左側のメニュー領域を`div`から`nav`に